### PR TITLE
Add Fedora support

### DIFF
--- a/tools/defaultmgr.sh
+++ b/tools/defaultmgr.sh
@@ -10,3 +10,7 @@ MKINIT=/etc/mkinitcpio.conf
 if [ -f "$MKINIT" ]; then
 	mkinitcpio -P linux
 fi
+DRACUT=/etc/dracut.conf
+if [ -f "$DRACUT" ]; then
+	dracut -f
+fi

--- a/tools/vfiomgr.sh
+++ b/tools/vfiomgr.sh
@@ -10,3 +10,7 @@ MKINIT=/etc/mkinitcpio.conf
 if [ -f "$MKINIT" ]; then
 	mkinitcpio -P linux
 fi
+DRACUT=/etc/dracut.conf
+if [ -f "$DRACUT" ]; then
+	dracut -f
+fi


### PR DESCRIPTION
Fedora doesn't seem to have `update-initramfs` or `mkinitcpio`, but has `dracut` for generating initramfs/initrd images. So, instead use `dracut` if it exists