### PR TITLE
Fix audio edge cases

### DIFF
--- a/py/load.py
+++ b/py/load.py
@@ -26,7 +26,7 @@ def load():
 
     # Get device data
     print("Gathering device data...")
-    lspci_res = subprocess.check_output("lspci -nn | grep -E 'Audio device|VGA'", shell=True).decode("utf-8").splitlines()
+    lspci_res = subprocess.check_output("lspci -nn | grep -iE 'Audio device|VGA'", shell=True).decode("utf-8").splitlines()
     
     # Prepare device data cache
     print(f"Found {len(lspci_res)} devices. Preparing data.json payload...")


### PR DESCRIPTION
Some cards are listed as `Multimedia audio device`, causing them to not be detected