### PR TITLE
EndeavourOS bugfix

### DIFF
--- a/tools/defaultmgr.sh
+++ b/tools/defaultmgr.sh
@@ -10,7 +10,32 @@ MKINIT=/etc/mkinitcpio.conf
 if [ -f "$MKINIT" ]; then
 	mkinitcpio -P linux
 fi
+
 DRACUT=/etc/dracut.conf
+update_dracut_image() {
+
+	DISTRO=$(lsb_release -is)
+
+	# EndeavourOS needs special command
+	if [ "$DISTRO" = "EndeavourOS" ]; then
+
+		# If user has grub
+		GRUB=/etc/default/grub
+		if [ -f "$GRUB" ]; then
+			dracut-rebuild
+		fi
+
+		# If user has systemd-boot
+		SYSD=/boot/loader/loader.conf
+		if [ -f "$SYSD" ]; then
+			reinstall-kernels
+		fi
+	
+	# default way
+	else 
+		dracut -f
+	fi 
+}
 if [ -f "$DRACUT" ]; then
-	dracut -f
+	update_dracut_image
 fi

--- a/tools/defaultmgr.sh
+++ b/tools/defaultmgr.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Get this script's directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 echo "Removing configuration file..."
 rm /etc/modprobe.d/vfio.conf
 echo "Rebuilding system images..."
@@ -12,30 +16,7 @@ if [ -f "$MKINIT" ]; then
 fi
 
 DRACUT=/etc/dracut.conf
-update_dracut_image() {
-
-	DISTRO=$(lsb_release -is)
-
-	# EndeavourOS needs special command
-	if [ "$DISTRO" = "EndeavourOS" ]; then
-
-		# If user has grub
-		GRUB=/etc/default/grub
-		if [ -f "$GRUB" ]; then
-			dracut-rebuild
-		fi
-
-		# If user has systemd-boot
-		SYSD=/boot/loader/loader.conf
-		if [ -f "$SYSD" ]; then
-			reinstall-kernels
-		fi
-	
-	# default way
-	else 
-		dracut -f
-	fi 
-}
+source $SCRIPT_DIR/dracut-utils
 if [ -f "$DRACUT" ]; then
 	update_dracut_image
 fi

--- a/tools/dracut-utils
+++ b/tools/dracut-utils
@@ -2,9 +2,7 @@
 
 update_dracut_image() {
 
-	DISTRO=$(lsb_release -is)
-
-    kdialog --password "Hello"    
+	DISTRO=$(lsb_release -is)    
 
 	# EndeavourOS needs special command
 	if [ "$DISTRO" = "EndeavourOS" ]; then

--- a/tools/dracut-utils
+++ b/tools/dracut-utils
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+update_dracut_image() {
+
+	DISTRO=$(lsb_release -is)
+
+    kdialog --password "Hello"    
+
+	# EndeavourOS needs special command
+	if [ "$DISTRO" = "EndeavourOS" ]; then
+
+		# If user has grub
+		GRUB=/etc/default/grub
+		if [ -f "$GRUB" ]; then
+			dracut-rebuild
+		fi
+
+		# If user has systemd-boot
+		SYSD=/boot/loader/loader.conf
+		if [ -f "$SYSD" ]; then
+			reinstall-kernels
+		fi
+	
+	# default way
+	else 
+		dracut -f
+	fi 
+}

--- a/tools/fts.sh
+++ b/tools/fts.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Get this script's directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 i=0
 #Add IOMMU to GRUB conf, then make the config.
 GRUB=/etc/default/grub
@@ -166,30 +170,7 @@ fi
 
 # Dracut VFIO hooks
 DRACUT=/etc/dracut.conf
-update_dracut_image() {
-
-	DISTRO=$(lsb_release -is)
-
-	# EndeavourOS needs special command
-	if [ "$DISTRO" = "EndeavourOS" ]; then
-
-		# If user has grub
-		GRUB=/etc/default/grub
-		if [ -f "$GRUB" ]; then
-			dracut-rebuild
-		fi
-
-		# If user has systemd-boot
-		SYSD=/boot/loader/loader.conf
-		if [ -f "$SYSD" ]; then
-			reinstall-kernels
-		fi
-	
-	# default way
-	else 
-		dracut -f
-	fi 
-}
+source $SCRIPT_DIR/dracut-utils
 if [ -f "$DRACUT" ]; then
 	DRACUT_DESTINATION=/etc/dracut.conf.d/10-vfio.conf
 	echo "Writing to $DRACUT_DESTINATION..."

--- a/tools/fts.sh
+++ b/tools/fts.sh
@@ -174,11 +174,13 @@ update_dracut_image() {
 	if [ "$DISTRO" = "EndeavourOS" ]; then
 
 		# If user has grub
+		GRUB=/etc/default/grub
 		if [ -f "$GRUB" ]; then
 			dracut-rebuild
 		fi
 
 		# If user has systemd-boot
+		SYSD=/boot/loader/loader.conf
 		if [ -f "$SYSD" ]; then
 			reinstall-kernels
 		fi

--- a/tools/vfiomgr.sh
+++ b/tools/vfiomgr.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Get this script's directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 echo "Copying configuration file..."
 cp ./vfio.conf /etc/modprobe.d/
 echo "Rebuilding system images..."
@@ -11,30 +15,7 @@ if [ -f "$MKINIT" ]; then
 	mkinitcpio -P linux
 fi
 DRACUT=/etc/dracut.conf
-update_dracut_image() {
-
-	DISTRO=$(lsb_release -is)
-
-	# EndeavourOS needs special command
-	if [ "$DISTRO" = "EndeavourOS" ]; then
-
-		# If user has grub
-		GRUB=/etc/default/grub
-		if [ -f "$GRUB" ]; then
-			dracut-rebuild
-		fi
-
-		# If user has systemd-boot
-		SYSD=/boot/loader/loader.conf
-		if [ -f "$SYSD" ]; then
-			reinstall-kernels
-		fi
-	
-	# default way
-	else 
-		dracut -f
-	fi 
-}
+source $SCRIPT_DIR/dracut-utils
 if [ -f "$DRACUT" ]; then
 	update_dracut_image
 fi

--- a/tools/vfiomgr.sh
+++ b/tools/vfiomgr.sh
@@ -11,6 +11,30 @@ if [ -f "$MKINIT" ]; then
 	mkinitcpio -P linux
 fi
 DRACUT=/etc/dracut.conf
+update_dracut_image() {
+
+	DISTRO=$(lsb_release -is)
+
+	# EndeavourOS needs special command
+	if [ "$DISTRO" = "EndeavourOS" ]; then
+
+		# If user has grub
+		GRUB=/etc/default/grub
+		if [ -f "$GRUB" ]; then
+			dracut-rebuild
+		fi
+
+		# If user has systemd-boot
+		SYSD=/boot/loader/loader.conf
+		if [ -f "$SYSD" ]; then
+			reinstall-kernels
+		fi
+	
+	# default way
+	else 
+		dracut -f
+	fi 
+}
 if [ -f "$DRACUT" ]; then
-	dracut -f
+	update_dracut_image
 fi


### PR DESCRIPTION
I noticed that dracut rebuild actually doesn't work, because at the stage where ids are added to modules.d, the app uses `dracut -f` instead of expected EOS commands like `dracut-rebuild` and `reinstall-kernels`. I restructured the code to have dracut functionality in a separate file and `source` it into others so that if anything changes for dracut, you don't have to change everything in all 3 files.